### PR TITLE
Support Variadic options for —apply-tag

### DIFF
--- a/node/.idea/edge-auth.iml
+++ b/node/.idea/edge-auth.iml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
+  <component name="ModuleRunConfigurationManager">
+    <shared />
+  </component>
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.tmp" />

--- a/node/package.json
+++ b/node/package.json
@@ -18,7 +18,7 @@
     "node": ">=10.15.3"
   },
   "devDependencies": {
-    "commander": "^3.0.0",
+    "commander": "^7.2.0",
     "eslint": "6.1.0",
     "eslint-plugin-notice": "0.8.8",
     "jest": "^24.9.0",

--- a/node/package.json
+++ b/node/package.json
@@ -13,12 +13,13 @@
     "lint": "eslint . --cache --ignore-path .gitignore",
     "lint:fix": "eslint . --fix --ignore-path .gitignore"
   },
-  "dependencies": {},
+  "dependencies": {
+    "commander": "^7.2.0"
+  },
   "engines": {
     "node": ">=10.15.3"
   },
   "devDependencies": {
-    "commander": "^7.2.0",
     "eslint": "6.1.0",
     "eslint-plugin-notice": "0.8.8",
     "jest": "^24.9.0",

--- a/node/src/TokenBuilder.js
+++ b/node/src/TokenBuilder.js
@@ -302,6 +302,20 @@ TokenBuilder.prototype.applyTag = function(tag) {
 };
 
 /**
+ * Apply the tag to the stream when it is setup. (optional)
+ *
+ * @param tags array of tags to be added to the new stream
+ * @returns {TokenBuilder} itself
+ */
+TokenBuilder.prototype.applyTags = function(tags) {
+  for (var i = 0; i < tags.length; i++) {
+    this.applyTag(tags[i]);
+  }
+
+  return this;
+};
+
+/**
  * Build the signed token
  *
  * @returns {String} the signed token that can be used with the Phenix platform

--- a/node/src/edgeAuth.js
+++ b/node/src/edgeAuth.js
@@ -36,74 +36,75 @@ program
   .option('-m, --room <roomId>', '[STREAMING] Token is limited to the given room')
   .option('-n, --roomAlias <roomAlias>', '[STREAMING] Token is limited to the given room alias')
   .option('-t, --tag <tag>', '[STREAMING] Token is limited to the given origin stream tag')
-  .option('-r, --applyTag <applyTag>', '[REPORTING] Apply tag to the new stream');
+  .option('-r, --applyTag <applyTag...>', '[REPORTING] Apply tag to the new stream');
 
 program.parse(process.argv);
 
+const options = program.opts();
 const tokenBuilder = new TokenBuilder()
-  .withApplicationId(program.applicationId)
-  .withSecret(program.secret);
+  .withApplicationId(options.applicationId)
+  .withSecret(options.secret);
 
-if (program.uri) {
-  tokenBuilder.withUri(program.uri);
+if (options.uri) {
+  tokenBuilder.withUri(options.uri);
 }
 
-if (program.expiresAt !== undefined) {
-  tokenBuilder.expiresAt(new Date(parseInt(program.expiresAt, 10)));
+if (options.expiresAt !== undefined) {
+  tokenBuilder.expiresAt(new Date(parseInt(options.expiresAt, 10)));
 } else {
-  tokenBuilder.expiresInSeconds(parseInt(program.expiresInSeconds || defaultExpirationInSeconds, 10));
+  tokenBuilder.expiresInSeconds(parseInt(options.expiresInSeconds || defaultExpirationInSeconds, 10));
 }
 
-if (program.authenticationOnly) {
+if (options.authenticationOnly) {
   tokenBuilder.forAuthenticateOnly();
 }
 
-if (program.streamingOnly) {
+if (options.streamingOnly) {
   tokenBuilder.forStreamingOnly();
 }
 
-if (program.publishingOnly) {
+if (options.publishingOnly) {
   tokenBuilder.forPublishingOnly();
 }
 
-if (program.capabilities) {
-  program.capabilities.split(',').forEach((capability) => tokenBuilder.withCapability(capability));
+if (options.capabilities) {
+  options.capabilities.split(',').forEach((capability) => tokenBuilder.withCapability(capability));
 }
 
-if (program.sessionId) {
-  tokenBuilder.forSession(program.sessionId);
+if (options.sessionId) {
+  tokenBuilder.forSession(options.sessionId);
 }
 
-if (program.remoteAddress) {
-  tokenBuilder.forRemoteAddress(program.remoteAddress);
+if (options.remoteAddress) {
+  tokenBuilder.forRemoteAddress(options.remoteAddress);
 }
 
-if (program.originStreamId) {
-  tokenBuilder.forOriginStream(program.originStreamId);
+if (options.originStreamId) {
+  tokenBuilder.forOriginStream(options.originStreamId);
 }
 
-if (program.channel) {
-  tokenBuilder.forChannel(program.channel);
+if (options.channel) {
+  tokenBuilder.forChannel(options.channel);
 }
 
-if (program.channelAlias) {
-  tokenBuilder.forChannelAlias(program.channelAlias);
+if (options.channelAlias) {
+  tokenBuilder.forChannelAlias(options.channelAlias);
 }
 
-if (program.room) {
-  tokenBuilder.forRoom(program.room);
+if (options.room) {
+  tokenBuilder.forRoom(options.room);
 }
 
-if (program.roomAlias) {
-  tokenBuilder.forRoomAlias(program.roomAlias);
+if (options.roomAlias) {
+  tokenBuilder.forRoomAlias(options.roomAlias);
 }
 
-if (program.tag) {
-  tokenBuilder.forTag(program.tag);
+if (options.tag) {
+  tokenBuilder.forTag(options.tag);
 }
 
-if (program.applyTag) {
-  tokenBuilder.applyTag(program.applyTag);
+if (options.applyTag) {
+  tokenBuilder.applyTags(options.applyTag);
 }
 
 const tokenObject = tokenBuilder.value();


### PR DESCRIPTION
I realized that while some of the code _seems_ to support having multiple applyTags, it only really works if you use the TokenBuilder. In this PR, I upgrade commander (including needing to change the way we address `options` to match the jump from 3.0 to 7.0 of commander.js) and also support multiple --applyTag calls.

Docs here: https://github.com/tj/commander.js#variadic-option
