### PR TITLE
EdgeAuth Variadic —applyTage option

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -18,7 +18,7 @@
     "node": ">=10.15.3"
   },
   "devDependencies": {
-    "commander": "^3.0.0",
+    "commander": "^7.2.0",
     "eslint": "6.1.0",
     "eslint-plugin-notice": "0.8.8",
     "jest": "^24.9.0",

--- a/node/src/TokenBuilder.js
+++ b/node/src/TokenBuilder.js
@@ -302,20 +302,6 @@ TokenBuilder.prototype.applyTag = function(tag) {
 };
 
 /**
- * Apply the tag to the stream when it is setup. (optional)
- *
- * @param tags array of tags to be added to the new stream
- * @returns {TokenBuilder} itself
- */
-TokenBuilder.prototype.applyTags = function(tags) {
-  for (var i = 0; i < tags.length; i++) {
-    this.applyTag(tags[i]);
-  }
-
-  return this;
-};
-
-/**
  * Build the signed token
  *
  * @returns {String} the signed token that can be used with the Phenix platform

--- a/node/src/TokenBuilder.js
+++ b/node/src/TokenBuilder.js
@@ -302,6 +302,20 @@ TokenBuilder.prototype.applyTag = function(tag) {
 };
 
 /**
+ * Apply the tag to the stream when it is setup. (optional)
+ *
+ * @param tags array of tags to be added to the new stream
+ * @returns {TokenBuilder} itself
+ */
+TokenBuilder.prototype.applyTags = function(tags) {
+  for (var i = 0; i < tags.length; i++) {
+    this.applyTag(tags[i]);
+  }
+
+  return this;
+};
+
+/**
  * Build the signed token
  *
  * @returns {String} the signed token that can be used with the Phenix platform

--- a/node/src/edgeAuth.js
+++ b/node/src/edgeAuth.js
@@ -104,7 +104,9 @@ if (options.tag) {
 }
 
 if (options.applyTag) {
-  tokenBuilder.applyTags(options.applyTag);
+  for (var i = 0; i < options.applyTag.length; i++) {
+    tokenBuilder.applyTag(options.applyTag[i]);
+  }
 }
 
 const tokenObject = tokenBuilder.value();

--- a/node/src/edgeAuth.js
+++ b/node/src/edgeAuth.js
@@ -36,74 +36,75 @@ program
   .option('-m, --room <roomId>', '[STREAMING] Token is limited to the given room')
   .option('-n, --roomAlias <roomAlias>', '[STREAMING] Token is limited to the given room alias')
   .option('-t, --tag <tag>', '[STREAMING] Token is limited to the given origin stream tag')
-  .option('-r, --applyTag <applyTag>', '[REPORTING] Apply tag to the new stream');
+  .option('-r, --applyTag <applyTag...>', '[REPORTING] Apply tag to the new stream');
 
 program.parse(process.argv);
 
+const options = program.opts();
 const tokenBuilder = new TokenBuilder()
-  .withApplicationId(program.applicationId)
-  .withSecret(program.secret);
+  .withApplicationId(options.applicationId)
+  .withSecret(options.secret);
 
-if (program.uri) {
-  tokenBuilder.withUri(program.uri);
+if (options.uri) {
+  tokenBuilder.withUri(options.uri);
 }
 
-if (program.expiresAt !== undefined) {
-  tokenBuilder.expiresAt(new Date(parseInt(program.expiresAt, 10)));
+if (options.expiresAt !== undefined) {
+  tokenBuilder.expiresAt(new Date(parseInt(options.expiresAt, 10)));
 } else {
-  tokenBuilder.expiresInSeconds(parseInt(program.expiresInSeconds || defaultExpirationInSeconds, 10));
+  tokenBuilder.expiresInSeconds(parseInt(options.expiresInSeconds || defaultExpirationInSeconds, 10));
 }
 
-if (program.authenticationOnly) {
+if (options.authenticationOnly) {
   tokenBuilder.forAuthenticateOnly();
 }
 
-if (program.streamingOnly) {
+if (options.streamingOnly) {
   tokenBuilder.forStreamingOnly();
 }
 
-if (program.publishingOnly) {
+if (options.publishingOnly) {
   tokenBuilder.forPublishingOnly();
 }
 
-if (program.capabilities) {
-  program.capabilities.split(',').forEach((capability) => tokenBuilder.withCapability(capability));
+if (options.capabilities) {
+  options.capabilities.split(',').forEach((capability) => tokenBuilder.withCapability(capability));
 }
 
-if (program.sessionId) {
-  tokenBuilder.forSession(program.sessionId);
+if (options.sessionId) {
+  tokenBuilder.forSession(options.sessionId);
 }
 
-if (program.remoteAddress) {
-  tokenBuilder.forRemoteAddress(program.remoteAddress);
+if (options.remoteAddress) {
+  tokenBuilder.forRemoteAddress(options.remoteAddress);
 }
 
-if (program.originStreamId) {
-  tokenBuilder.forOriginStream(program.originStreamId);
+if (options.originStreamId) {
+  tokenBuilder.forOriginStream(options.originStreamId);
 }
 
-if (program.channel) {
-  tokenBuilder.forChannel(program.channel);
+if (options.channel) {
+  tokenBuilder.forChannel(options.channel);
 }
 
-if (program.channelAlias) {
-  tokenBuilder.forChannelAlias(program.channelAlias);
+if (options.channelAlias) {
+  tokenBuilder.forChannelAlias(options.channelAlias);
 }
 
-if (program.room) {
-  tokenBuilder.forRoom(program.room);
+if (options.room) {
+  tokenBuilder.forRoom(options.room);
 }
 
-if (program.roomAlias) {
-  tokenBuilder.forRoomAlias(program.roomAlias);
+if (options.roomAlias) {
+  tokenBuilder.forRoomAlias(options.roomAlias);
 }
 
-if (program.tag) {
-  tokenBuilder.forTag(program.tag);
+if (options.tag) {
+  tokenBuilder.forTag(options.tag);
 }
 
-if (program.applyTag) {
-  tokenBuilder.applyTag(program.applyTag);
+if (options.applyTag) {
+  tokenBuilder.applyTags(options.applyTag);
 }
 
 const tokenObject = tokenBuilder.value();


### PR DESCRIPTION
Discovered while working on @VeueLive’s code, that additional tags weren’t possible with the current command line API.

Variadic options were added later in Commander.js and so we upgrade Commander here and add a `applyTags` endpoint to the token builder.

(This is the new PR open with a clean commit history and none of the unwanted things!)