### PR TITLE
Make Python behavior consistent with other versions

### DIFF
--- a/python/edgeauth/token_builder.py
+++ b/python/edgeauth/token_builder.py
@@ -66,11 +66,11 @@ class TokenBuilder:
             raise TypeError('Capability must be a string')
 
         token = self.token
-        capabilities = set(token['capabilities']) if 'capabilities' in token else set([])
+        capabilities = token['capabilities'] if 'capabilities' in token else []
 
-        capabilities.add(capability)
+        capabilities.append(capability)
 
-        self.token['capabilities'] = sorted(list(capabilities))
+        self.token['capabilities'] = capabilities
 
         return self
 
@@ -237,11 +237,11 @@ class TokenBuilder:
             raise TypeError('Tag must be a string')
 
         token = self.token
-        apply_tags = set(token['applyTags']) if 'applyTags' in token else set()
+        apply_tags = token['applyTags'] if 'applyTags' in token else []
 
-        apply_tags.add(tag)
+        apply_tags.append(tag)
 
-        self.token['applyTags'] = list(apply_tags)
+        self.token['applyTags'] = apply_tags
 
         return self
 


### PR DESCRIPTION
 - Make capabilities into a simple list: `TokenBuilder.with_capability` now just appends a value to the list, instead of using a set to make capability values unique.

 - Make applied tags into a simple list: same behavior for `TokenBuilder.apply_tag` as for the capabilities list.

This makes the behavior of the Python code the same as the Java and Javascript versions of the library.